### PR TITLE
Use "build" as dist-folder to load compiled website

### DIFF
--- a/.github/workflows/deploy-now.yaml
+++ b/.github/workflows/deploy-now.yaml
@@ -48,4 +48,4 @@ jobs:
           branch-id: ${{ steps.project.outputs.branch-id }}
           service-host: api-eu.ionos.space
           api-key: ${{ secrets.IONOS_API_KEY }}
-          dist-folder: public
+          dist-folder: build


### PR DESCRIPTION
Hello @tonydang97,

the dist-folder inside the deployment workflow was wrong. Therefore the index.html from "/public" was used which is empty.

Best regards
Marlon